### PR TITLE
Add renderText method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 assets
+.idea

--- a/Example/index.ios.js
+++ b/Example/index.ios.js
@@ -11,7 +11,7 @@ const {
   View,
   LinkingIOS,
   AlertIOS,
-} = React;
+  } = React;
 
 import ParsedText from 'react-native-parsed-text';
 
@@ -34,6 +34,10 @@ class Example extends React.Component {
     AlertIOS.alert(`send email to ${email}`);
   }
 
+  renderText(string) {
+    return `^^${string}^^`;
+  }
+
   render() {
     return (
       <View style={styles.container}>
@@ -45,11 +49,12 @@ class Example extends React.Component {
               {type: 'phone',        style: styles.phone, onPress: this.handlePhonePress},
               {type: 'email',        style: styles.email, onPress: this.handleEmailPress},
               {pattern: /Bob|David/, style: styles.name, onPress: this.handleNamePress},
+              {pattern: /Bob|David/, style: styles.name, onPress: this.handleNamePress, renderText: this.renderText},
               {pattern: /42/,        style: styles.magicNumber},
               {pattern: /#(\w+)/,    style: styles.hashTag},
             ]
           }
-        >
+          >
           Hello this is an example of the ParsedText, links like http://www.google.com or http://www.facebook.com are clickable and phone number 444-555-6666 can call too.
           But you can also do more with this package, for example Bob will change style and David too. foo@gmail.com
           And the magic number is 42!

--- a/Example/index.ios.js
+++ b/Example/index.ios.js
@@ -35,7 +35,9 @@ class Example extends React.Component {
   }
 
   renderText(string) {
-    return `^^${string}^^`;
+    let pattern = /\[(@[^:]+):([^\]]+)\]/i;
+    let match = string.match(pattern);
+    return `^^${match[1]}^^`;
   }
 
   render() {
@@ -45,18 +47,18 @@ class Example extends React.Component {
           style={styles.text}
           parse={
             [
-              {type: 'url',          style: styles.url, onPress: this.handleUrlPress},
-              {type: 'phone',        style: styles.phone, onPress: this.handlePhonePress},
-              {type: 'email',        style: styles.email, onPress: this.handleEmailPress},
-              {pattern: /Bob|David/, style: styles.name, onPress: this.handleNamePress},
-              {pattern: /Bob|David/, style: styles.name, onPress: this.handleNamePress, renderText: this.renderText},
-              {pattern: /42/,        style: styles.magicNumber},
-              {pattern: /#(\w+)/,    style: styles.hashTag},
+              {type: 'url',                       style: styles.url, onPress: this.handleUrlPress},
+              {type: 'phone',                     style: styles.phone, onPress: this.handlePhonePress},
+              {type: 'email',                     style: styles.email, onPress: this.handleEmailPress},
+              {pattern: /Bob|David/,              style: styles.name, onPress: this.handleNamePress},
+              {pattern: /\[(@[^:]+):([^\]]+)\]/i, style: styles.username, onPress: this.handleNamePress, renderText: this.renderText},
+              {pattern: /42/,                     style: styles.magicNumber},
+              {pattern: /#(\w+)/,                 style: styles.hashTag},
             ]
           }
           >
           Hello this is an example of the ParsedText, links like http://www.google.com or http://www.facebook.com are clickable and phone number 444-555-6666 can call too.
-          But you can also do more with this package, for example Bob will change style and David too. foo@gmail.com
+          But you can also do more with this package, for example Bob will change style and David too. You should mention [@michel:5455345] about that. foo@gmail.com
           And the magic number is 42!
           #react #react-native
         </ParsedText>
@@ -94,6 +96,11 @@ const styles = StyleSheet.create({
 
   name: {
     color: 'red',
+  },
+
+  username: {
+    color: 'green',
+    fontWeight: 'bold'
   },
 
   magicNumber: {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All the props are passed down to a new `Text` Component if there is a matching t
 I you specify a renderText method, it will be called to change the displayed children.
 
 eg: 
-Your str is ```'Mention [@michel:5455345]'``` where 5455345 is ID of this user and @user the value to display on interface.
+Your str is ```'Mention [@michel:5455345]'``` where 5455345 is ID of this user and @michel the value to display on interface.
 Your pattern for ID & username extraction : ```/\[(@[^:]+):([^\]]+)\]/i```
 Your renderText method : 
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ class Example extends React.Component {
     AlertIOS.alert(`send email to ${email}`);
   }
 
+  renderText(string) {
+    return `^^${string}^^`;
+  }
+  
   render() {
     return (
       <View style={styles.container}>
@@ -42,12 +46,13 @@ class Example extends React.Component {
           style={styles.text}
           parse={
             [
-              {type: 'url',          style: styles.url, onPress: this.handleUrlPress},
-              {type: 'phone',        style: styles.phone, onPress: this.handlePhonePress},
-              {type: 'email',        style: styles.email, onPress: this.handleEmailPress},
-              {pattern: /Bob|David/, style: styles.name, onPress: this.handleNamePress},
-              {pattern: /42/,        style: styles.magicNumber},
-              {pattern: /#(\w+)/,    style: styles.hashTag},
+              {type: 'url',                   style: styles.url, onPress: this.handleUrlPress},
+              {type: 'phone',                 style: styles.phone, onPress: this.handlePhonePress},
+              {type: 'email',                 style: styles.email, onPress: this.handleEmailPress},
+              {pattern: /Bob|David/,          style: styles.name, onPress: this.handleNamePress},
+              {pattern: /Bob|David/,          style: styles.name, onPress: this.handleNamePress, renderChildren: this.renderText},
+              {pattern: /42/,                 style: styles.magicNumber},
+              {pattern: /#(\w+)/,             style: styles.hashTag},
             ]
           }
         >
@@ -110,6 +115,13 @@ const styles = StyleSheet.create({
 
 `npm install --save react-native-parsed-text`
 
+## Test using mocha
+
+```
+mocha --compilers js:babel/register
+```
+
 ## TODO
 
 * Add nested text parsing
+

--- a/README.md
+++ b/README.md
@@ -5,6 +5,22 @@ Currently there are 3 predefined types: `url`, `phone` and `email`.
 
 All the props are passed down to a new `Text` Component if there is a matching text. If those are functions they will receive as param the value of the text.
 
+I you specify a renderText method, it will be called to change the displayed children.
+
+eg: 
+Your str is ```'Mention [@michel:5455345]'``` where 5455345 is ID of this user and @user the value to display on interface.
+Your pattern for ID & username extraction : ```/\[(@[^:]+):([^\]]+)\]/i```
+Your renderText method : 
+```
+renderText(string) {
+    let pattern = /\[(@[^:]+):([^\]]+)\]/i;
+    let match = string.match(pattern);
+    return `^^${match[1]}^^`;
+  }
+```
+Displayed text will be : ```Mention ^^@michel^^```
+
+
 ## Proptypes
 
 `ParsedText` can receive [Text PropTypes](https://facebook.github.io/react-native/docs/text.html).
@@ -36,7 +52,9 @@ class Example extends React.Component {
   }
 
   renderText(string) {
-    return `^^${string}^^`;
+    let pattern = /\[(@[^:]+):([^\]]+)\]/i;
+    let match = string.match(pattern);
+    return `^^${match[1]}^^`;
   }
   
   render() {
@@ -46,13 +64,13 @@ class Example extends React.Component {
           style={styles.text}
           parse={
             [
-              {type: 'url',                   style: styles.url, onPress: this.handleUrlPress},
-              {type: 'phone',                 style: styles.phone, onPress: this.handlePhonePress},
-              {type: 'email',                 style: styles.email, onPress: this.handleEmailPress},
-              {pattern: /Bob|David/,          style: styles.name, onPress: this.handleNamePress},
-              {pattern: /Bob|David/,          style: styles.name, onPress: this.handleNamePress, renderChildren: this.renderText},
-              {pattern: /42/,                 style: styles.magicNumber},
-              {pattern: /#(\w+)/,             style: styles.hashTag},
+              {type: 'url',                       style: styles.url, onPress: this.handleUrlPress},
+              {type: 'phone',                     style: styles.phone, onPress: this.handlePhonePress},
+              {type: 'email',                     style: styles.email, onPress: this.handleEmailPress},
+              {pattern: /Bob|David/,              style: styles.name, onPress: this.handleNamePress},
+              {pattern: /\[(@[^:]+):([^\]]+)\]/i, style: styles.username, onPress: this.handleNamePress, renderText: this.renderText},
+              {pattern: /42/,                     style: styles.magicNumber},
+              {pattern: /#(\w+)/,                 style: styles.hashTag},
             ]
           }
         >
@@ -96,6 +114,11 @@ const styles = StyleSheet.create({
   name: {
     color: 'red',
   },
+  
+  username: {
+    color: 'green',
+    fontWeight: 'bold'
+  },
 
   magicNumber: {
     fontSize: 42,
@@ -114,12 +137,6 @@ const styles = StyleSheet.create({
 ## Install
 
 `npm install --save react-native-parsed-text`
-
-## Test using mocha
-
-```
-mocha --compilers js:babel/register
-```
 
 ## TODO
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-parsed-text",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Parse text and make them into multiple React Native Text elements",
   "main": "lib/ParsedText.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-parsed-text",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Parse text and make them into multiple React Native Text elements",
   "main": "lib/ParsedText.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-parsed-text",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "Parse text and make them into multiple React Native Text elements",
   "main": "lib/ParsedText.js",
   "scripts": {

--- a/src/lib/TextExtraction.js
+++ b/src/lib/TextExtraction.js
@@ -79,9 +79,14 @@ class TextExtraction {
       }
     });
 
+    var children = text;
+    if (props.renderText && typeof props.renderText === 'function') {
+      children = props.renderText(children);
+    }
+
     return {
       ...props,
-      children: text,
+      children: children,
       _matched: true,
     };
   }

--- a/src/lib/TextExtraction.js
+++ b/src/lib/TextExtraction.js
@@ -70,7 +70,7 @@ class TextExtraction {
     let props = {};
 
     Object.keys(matchedPattern).forEach((key) => {
-      if (key === 'pattern') { return; }
+      if (key === 'pattern' || key === 'renderText') { return; }
 
       if (typeof matchedPattern[key] === 'function') {
         props[key] = () => matchedPattern[key](text);
@@ -80,8 +80,8 @@ class TextExtraction {
     });
 
     var children = text;
-    if (props.renderText && typeof props.renderText === 'function') {
-      children = props.renderText(children);
+    if (matchedPattern.renderText && typeof matchedPattern.renderText === 'function') {
+      children = matchedPattern.renderText(children);
     }
 
     return {

--- a/test/TextExtraction.test.js
+++ b/test/TextExtraction.test.js
@@ -86,7 +86,39 @@ describe('TextExtraction', () => {
         {children: ' is good.'},
       ]);
     });
+  });
 
+  describe('renderText prop', () => {
+    it('checks that renderText is a function', (done) => {
+      const textExtraction = new TextExtraction('hello Bob, David, Michel', [
+        { pattern: /Bob|David/, renderText: 'foo'}
+      ]);
+
+      const parsedText = textExtraction.parse();
+
+      expect(parsedText[0]).to.eql({children: 'hello '});
+      expect(parsedText[1].children).to.eql('Bob');
+      expect(parsedText[2].children).to.eql(', ');
+      expect(parsedText[3].children).to.eql('David');
+      expect(parsedText[4].children).to.eql(', Michel');
+
+      done();
+    });
+    it('pass the values to the callbacks', (done) => {
+      const textExtraction = new TextExtraction('hello Bob, David, Michel', [
+        { pattern: /Bob|David/, renderText: (string) => { return `^^${string}^^`}}
+      ]);
+
+      const parsedText = textExtraction.parse();
+
+      expect(parsedText[0]).to.eql({children: 'hello '});
+      expect(parsedText[1].children).to.eql('^^Bob^^');
+      expect(parsedText[2].children).to.eql(', ');
+      expect(parsedText[3].children).to.eql('^^David^^');
+      expect(parsedText[4].children).to.eql(', Michel');
+
+      done();
+    });
   });
 
 });

--- a/test/TextExtraction.test.js
+++ b/test/TextExtraction.test.js
@@ -90,32 +90,30 @@ describe('TextExtraction', () => {
 
   describe('renderText prop', () => {
     it('checks that renderText is a function', (done) => {
-      const textExtraction = new TextExtraction('hello Bob, David, Michel', [
-        { pattern: /Bob|David/, renderText: 'foo'}
+      const textExtraction = new TextExtraction('Mention [@michel:561316513]', [
+        { pattern: /\[(@[^:]+):([^\]]+)\]/i, renderText: 'foo'}
       ]);
 
       const parsedText = textExtraction.parse();
 
-      expect(parsedText[0]).to.eql({children: 'hello '});
-      expect(parsedText[1].children).to.eql('Bob');
-      expect(parsedText[2].children).to.eql(', ');
-      expect(parsedText[3].children).to.eql('David');
-      expect(parsedText[4].children).to.eql(', Michel');
+      expect(parsedText[0]).to.eql({children: 'Mention '});
+      expect(parsedText[1]).to.eql({children: '[@michel:561316513]'});
 
       done();
     });
     it('pass the values to the callbacks', (done) => {
-      const textExtraction = new TextExtraction('hello Bob, David, Michel', [
-        { pattern: /Bob|David/, renderText: (string) => { return `^^${string}^^`}}
+      const textExtraction = new TextExtraction('Mention [@michel:561316513]', [
+        { pattern: /\[(@[^:]+):([^\]]+)\]/i, renderText: (string) => {
+          let pattern = /\[(@[^:]+):([^\]]+)\]/i;
+          let match = string.match(pattern);
+          return `^^${match[1]}^^`;
+        }}
       ]);
 
       const parsedText = textExtraction.parse();
 
-      expect(parsedText[0]).to.eql({children: 'hello '});
-      expect(parsedText[1].children).to.eql('^^Bob^^');
-      expect(parsedText[2].children).to.eql(', ');
-      expect(parsedText[3].children).to.eql('^^David^^');
-      expect(parsedText[4].children).to.eql(', Michel');
+      expect(parsedText[0]).to.eql({children: 'Mention '});
+      expect(parsedText[1].children).to.eql('^^@michel^^');
 
       done();
     });


### PR DESCRIPTION
I added a new prop 'renderText' that can modify the "children" value.

Useful for complex markup replace when searched pattern is not the value we want to display on interface.

e.g. : markup [@user:5455345] where 5455345 is ID of this user and @user the value to display on interface.