### PR TITLE
Moving all babel-plugin related things to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "babel-plugin-transform-react-display-name": "^6.0.14",
     "babel-plugin-transform-react-jsx": "^6.0.18",
     "babel-plugin-transform-regenerator": "^6.0.18",
-    "babel-register": "^6.3.13",
+    "babel-register": "^6.3.13"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,8 @@
     "react",
     "react-component"
   ],
-  "devDependencies": {
+  "dependencies": {
     "babel": "^6.3.13",
-    "babel-eslint": "^4.1.4",
     "babel-plugin-external-helpers-2": "^6.1.4",
     "babel-plugin-syntax-async-functions": "^6.0.14",
     "babel-plugin-syntax-class-properties": "^6.0.14",
@@ -51,6 +50,9 @@
     "babel-plugin-transform-react-jsx": "^6.0.18",
     "babel-plugin-transform-regenerator": "^6.0.18",
     "babel-register": "^6.3.13",
+  },
+  "devDependencies": {
+    "babel-eslint": "^4.1.4",
     "chai": "^3.4.0",
     "eslint": "^1.8.0",
     "eslint-plugin-react": "^3.7.1",


### PR DESCRIPTION
Just tried running this in RN 0.16 but the first line in your plugins in the `.babelrc` file throws a red screen:

`Unknown pluging "syntax-async-functions"`.

It makes sense because all the plugins are included in `devDependencies` in `package.json` so when I install it, it does not get them.

The other option would be to run a build step before publishing it.