### PR TITLE
NPM ignore .babelrc

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.bablerc


### PR DESCRIPTION
React Native throws error when present: 

Unknown plugin "syntax-async-functions" specified in "[app]/node_modules/react-native-parsed-text/"

Issue #10 