### PR TITLE
Forward native props to underlying native components

### DIFF
--- a/src/ParsedText.js
+++ b/src/ParsedText.js
@@ -34,6 +34,10 @@ class ParsedText extends React.Component {
     parse: null,
   };
 
+  setNativeProps(nativeProps) {
+    this._root.setNativeProps(nativeProps);
+  }
+
   getPatterns() {
     return this.props.parse.map((option) => {
       const {type, ...patternOption} = option;
@@ -66,7 +70,9 @@ class ParsedText extends React.Component {
 
   render() {
     return (
-      <ReactNative.Text {...this.props}>
+      <ReactNative.Text
+        ref={ref => this._root = ref}
+        {...this.props}>
         {this.getParsedText()}
       </ReactNative.Text>
     );


### PR DESCRIPTION
As a composite component, ParsedText does not have `setNativeProps` as a method. Certain React Native components rely on children having an accessible `setNativeProps` method to forward on properties to underlying native components. 

Some more details can be found in the React Native documentation: https://facebook.github.io/react-native/docs/direct-manipulation.html#composite-components-and-setnativeprops

For example, we currently cannot wrap a `<ParsedText>` with a `<TouchableHighlight>`:
```
<TouchableHighlight onPress={() => {}}>
  <ParsedText>
    The text to parse
  </ParsedText>
</TouchableHighlight>
```

TouchableHighlight requires that its child either has or forwards `setNativeProps` to a native component. 

**This PR fixes the component to correctly forward the native props, fixing compatibility with components such as TouchableHighlight.**