### PR TITLE
React 16 support & Babel plugin hotfix

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,7 +11,7 @@
     "transform-es2015-block-scoping",
     "transform-es2015-classes",
     "transform-es2015-computed-properties",
-    "transform-es2015-constants",
+    "check-es2015-constants",
     "transform-es2015-destructuring",
     ["transform-es2015-modules-commonjs", {"strict": false, "allowTopLevelThis": true}],
     "transform-es2015-parameters",

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "mocha": "^2.3.3"
   },
   "author": "jrichardlai",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  }
 }

--- a/src/ParsedText.js
+++ b/src/ParsedText.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactNative from 'react-native';
+import PropTypes from 'prop-types';
 
 import TextExtraction from './lib/TextExtraction';
 
@@ -9,14 +10,14 @@ const PATTERNS = {
   email: /\S+@\S+\.\S+/,
 };
 
-const defaultParseShape = React.PropTypes.shape({
+const defaultParseShape = PropTypes.shape({
   ...ReactNative.Text.propTypes,
-  type: React.PropTypes.oneOf(Object.keys(PATTERNS)).isRequired,
+  type: PropTypes.oneOf(Object.keys(PATTERNS)).isRequired,
 });
 
-const customParseShape = React.PropTypes.shape({
+const customParseShape = PropTypes.shape({
   ...ReactNative.Text.propTypes,
-  pattern: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.instanceOf(RegExp)]).isRequired,
+  pattern: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(RegExp)]).isRequired,
 });
 
 class ParsedText extends React.Component {
@@ -25,10 +26,10 @@ class ParsedText extends React.Component {
 
   static propTypes = {
     ...ReactNative.Text.propTypes,
-    parse: React.PropTypes.arrayOf(
-      React.PropTypes.oneOfType([defaultParseShape, customParseShape]),
+    parse: PropTypes.arrayOf(
+      PropTypes.oneOfType([defaultParseShape, customParseShape]),
     ),
-    childrenProps: React.PropTypes.shape(ReactNative.Text.propTypes),
+    childrenProps: PropTypes.shape(ReactNative.Text.propTypes),
   };
 
   static defaultProps = {


### PR DESCRIPTION
Use `prop-types` external package instead of deprecated `React.PropTypes`.

Renamed babel plugin to `check-es2015-constants`