### PR TITLE
Support one more digit on phone number

### DIFF
--- a/src/ParsedText.js
+++ b/src/ParsedText.js
@@ -5,7 +5,7 @@ import TextExtraction from './lib/TextExtraction';
 
 const PATTERNS = {
   url: /(https?:\/\/|www\.)[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/i,
-  phone: /[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}/,
+  phone: /[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,7}/,
   email: /\S+@\S+\.\S+/,
 };
 


### PR DESCRIPTION
Brazilian phone numbers are quite big.
Before it would skip the last digit: `+551698121619`0

PS: It still doesn't support the full format that we usually do here, e.g. `+55 (16) 9-8121-6190`