### PR TITLE
Replaced deprecated React.PropTypes with prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "devDependencies": {
     "babel": "^6.3.13",
+    "babel-eslint": "^4.1.4",
     "babel-plugin-external-helpers-2": "^6.1.4",
     "babel-plugin-syntax-async-functions": "^6.0.14",
     "babel-plugin-syntax-class-properties": "^6.0.14",
@@ -50,12 +51,14 @@
     "babel-plugin-transform-react-jsx": "^6.0.18",
     "babel-plugin-transform-regenerator": "^6.0.18",
     "babel-register": "^6.3.13",
-    "babel-eslint": "^4.1.4",
     "chai": "^3.4.0",
     "eslint": "^1.8.0",
     "eslint-plugin-react": "^3.7.1",
     "mocha": "^2.3.3"
   },
   "author": "jrichardlai",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "prop-types": "^15.6.0"
+  }
 }

--- a/src/ParsedText.js
+++ b/src/ParsedText.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactNative from 'react-native';
+import PropTypes from 'prop-types';
 
 import TextExtraction from './lib/TextExtraction';
 
@@ -9,14 +10,17 @@ const PATTERNS = {
   email: /\S+@\S+\.\S+/,
 };
 
-const defaultParseShape = React.PropTypes.shape({
+const defaultParseShape = PropTypes.shape({
   ...ReactNative.Text.propTypes,
-  type: React.PropTypes.oneOf(Object.keys(PATTERNS)).isRequired,
+  type: PropTypes.oneOf(Object.keys(PATTERNS)).isRequired,
 });
 
-const customParseShape = React.PropTypes.shape({
+const customParseShape = PropTypes.shape({
   ...ReactNative.Text.propTypes,
-  pattern: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.instanceOf(RegExp)]).isRequired,
+  pattern: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.instanceOf(RegExp),
+  ]).isRequired,
 });
 
 class ParsedText extends React.Component {
@@ -25,10 +29,10 @@ class ParsedText extends React.Component {
 
   static propTypes = {
     ...ReactNative.Text.propTypes,
-    parse: React.PropTypes.arrayOf(
-      React.PropTypes.oneOfType([defaultParseShape, customParseShape]),
+    parse: PropTypes.arrayOf(
+      PropTypes.oneOfType([defaultParseShape, customParseShape]),
     ),
-    childrenProps: React.PropTypes.shape(ReactNative.Text.propTypes),
+    childrenProps: PropTypes.shape(ReactNative.Text.propTypes),
   };
 
   static defaultProps = {


### PR DESCRIPTION

Won't compile when using React 16+ without this change
