### PR TITLE
Adding missing babel plugin into packege.json, adding test for urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "devDependencies": {
     "babel": "^6.3.13",
+    "babel-eslint": "^4.1.4",
     "babel-plugin-external-helpers-2": "^6.1.4",
     "babel-plugin-syntax-async-functions": "^6.0.14",
     "babel-plugin-syntax-class-properties": "^6.0.14",
@@ -38,7 +39,7 @@
     "babel-plugin-transform-es2015-constants": "^6.0.15",
     "babel-plugin-transform-es2015-destructuring": "^6.0.18",
     "babel-plugin-transform-es2015-for-of": "^6.0.14",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.1.3",
+    "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
     "babel-plugin-transform-es2015-parameters": "^6.0.18",
     "babel-plugin-transform-es2015-shorthand-properties": "^6.0.14",
     "babel-plugin-transform-es2015-spread": "^6.0.14",
@@ -50,7 +51,6 @@
     "babel-plugin-transform-react-jsx": "^6.0.18",
     "babel-plugin-transform-regenerator": "^6.0.18",
     "babel-register": "^6.3.13",
-    "babel-eslint": "^4.1.4",
     "chai": "^3.4.0",
     "eslint": "^1.8.0",
     "eslint-plugin-react": "^3.7.1",
@@ -59,6 +59,7 @@
   "author": "jrichardlai",
   "license": "MIT",
   "dependencies": {
+    "babel-plugin-check-es2015-constants": "6.22.0",
     "prop-types": "^15.5.10"
   }
 }

--- a/test/TextExtraction.test.js
+++ b/test/TextExtraction.test.js
@@ -42,6 +42,24 @@ describe('TextExtraction', () => {
       ]);
     });
 
+    it('return all matched urls', () => {
+      const urls = [
+        'https://website.bz',
+        'http://website2.it',
+        'https://t.co/hashKey',
+      ]
+      const textExtraction = new TextExtraction(
+        `this is my website ${urls[0]} and this is also ${urls[1]} ig this one also ${urls[2]}`,
+        [{ pattern: /(https?:\/\/|www\.)[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]{1,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/i }]
+      )
+
+      const parsedText = textExtraction.parse();
+      expect(parsedText[1].children).to.eql(urls[0])
+      expect(parsedText[3].children).to.eql(urls[1])
+      expect(parsedText[5].children).to.eql(urls[2])
+
+    })
+
     it('pass the values to the callbacks', (done) => {
       const textExtraction = new TextExtraction('hello foo', [
         { pattern: /foo/, onPress: (value) => expect(value).to.eql('foo') && done() },


### PR DESCRIPTION
There was a missing package, required by .babelrc so `npm run test` failed.

Also, a test when there a multiple links inside. 