### PR TITLE
Fix childrenProps not working

### DIFF
--- a/src/ParsedText.js
+++ b/src/ParsedText.js
@@ -80,7 +80,11 @@ class ParsedText extends React.Component {
     const { parse, childrenProps, ...remainder } = { ...this.props };
 
     return (
-      <Text ref={ref => (this._root = ref)} {...remainder}>
+      <Text
+        ref={ref => (this._root = ref)}
+        {...childrenProps}
+        {...remainder}
+      >
         {this.getParsedText()}
       </Text>
     );


### PR DESCRIPTION
I got issue when trying to set `childrenProps={{ allowFontScaling: false }}`. There is no effect because it just be set for inner `Text`.

![Simulator Screen Shot - iPhone X - 2020-05-29 at 21 31 45](https://user-images.githubusercontent.com/8109285/83272558-7c23c580-a1f5-11ea-89b0-ba687b2190f9.png)

After apply this fix
![Simulator Screen Shot - iPhone X - 2020-05-29 at 21 31 54](https://user-images.githubusercontent.com/8109285/83272668-a1b0cf00-a1f5-11ea-85a9-e4cee816f5b3.png)
