### PR TITLE
Feature: Non-exhaustive Matching Mode

### DIFF
--- a/src/ParsedText.d.ts
+++ b/src/ParsedText.d.ts
@@ -22,8 +22,16 @@ declare module 'react-native-parsed-text' {
   /**
    * If you want to provide a custom regexp, this is the configuration to use.
    * -- For historical reasons, all regexps are processed as if they have the global flag set.
+   * -- Use the nonExhaustiveModeMaxMatchCount property to match a limited number of matches.
+   */
   interface CustomParseShape extends BaseParseShape {
     pattern: string | RegExp;
+    /**
+     * Enables "non-exhaustive mode", where you can limit how many matches are found.
+     *
+     * If you want to match at most N things per-call to parse(), provide a positive number here.
+     */
+    nonExhaustiveModeMaxMatchCount?: number;
   }
 
   type ParseShape = DefaultParseShape | CustomParseShape;

--- a/src/ParsedText.js
+++ b/src/ParsedText.js
@@ -23,6 +23,7 @@ export const PATTERNS = {
  * Note: any additional keys/props are permitted, and will be passed along as props to the <Text> component!
  * @typedef {Object} DefaultParseShape
  * @property {KnownParsePattern} [type] key of the known pattern you'd like to configure
+ * @property {number} [nonExhaustiveModeMaxMatchCount] Enables "non-exhaustive mode", where you can limit how many matches are found. -- Must be a positive integer or Infinity matches are permitted
  * @property {Function} [renderText] arbitrary function to rewrite the matched string into something else
  * @property {Function} [onPress]
  * @property {Function} [onLongPress]
@@ -30,6 +31,7 @@ export const PATTERNS = {
 const defaultParseShape = PropTypes.shape({
   ...Text.propTypes,
   type: PropTypes.oneOf(Object.keys(PATTERNS)).isRequired,
+  nonExhaustiveMaxMatchCount: PropTypes.number,
 });
 
 const customParseShape = PropTypes.shape({

--- a/src/ParsedText.js
+++ b/src/ParsedText.js
@@ -36,6 +36,7 @@ const customParseShape = PropTypes.shape({
   ...Text.propTypes,
   pattern: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(RegExp)])
     .isRequired,
+  nonExhaustiveMaxMatchCount: PropTypes.number,
 });
 
 /**

--- a/src/lib/TextExtraction.js
+++ b/src/lib/TextExtraction.js
@@ -47,7 +47,6 @@ class TextExtraction {
         // Only allow for now one parsing
         if (parsedText._matched) {
           newParts.push(parsedText);
-
           return;
         }
 
@@ -66,7 +65,6 @@ class TextExtraction {
 
           if (++currentMatches > numberOfMatchesPermitted) {
             // Abort if we've exhausted our number of matches
-            parts.push({ children: textLeft });
             break;
           }
 

--- a/test/TextExtraction.test.js
+++ b/test/TextExtraction.test.js
@@ -320,6 +320,47 @@ describe('TextExtraction', () => {
       `);
     });
 
+    describe('non-exhaustive-mode', () => {
+      it('basic functions work', () => {
+        const ext = new TextExtraction('aaaa', [
+          {
+            pattern: /a/,
+            nonExhaustiveModeMaxMatchCount: 1,
+            renderText: () => 'z',
+          },
+        ]);
+        expect(
+          ext
+            .parse()
+            .map((chunk) => chunk.children)
+            .join(''),
+        ).toMatchInlineSnapshot(`"zaaa"`);
+      });
+      test.each([
+        ['undefined is', undefined, 'aaaa', 'zzzz'],
+        ['null is', null, 'aaaa', 'zzzz'],
+        ['zero is', 0, 'aaaa', 'zzzz'],
+        ['negative numbers are', -1, 'aaaa', 'zzzz'],
+        ['arbitrary objects are', {}, 'aaaa', 'zzzz'],
+      ])(
+        'nonsense nonExhaustiveModeMaxMatchCount values: %s treated like infinity/no-limit',
+        (msg, value, text, result) => {
+          expect(
+            new TextExtraction(text, [
+              {
+                pattern: /a/,
+                nonExhaustiveModeMaxMatchCount: value,
+                renderText: () => 'z',
+              },
+            ])
+              .parse()
+              .map((chunk) => chunk.children)
+              .join(''),
+          ).toEqual(result);
+        },
+      );
+    });
+
     it('respects the parsing order', () => {
       const textExtraction = new TextExtraction(
         'hello my website is http://foo.bar, bar is good.',

--- a/test/TextExtraction.test.js
+++ b/test/TextExtraction.test.js
@@ -322,20 +322,46 @@ describe('TextExtraction', () => {
 
     describe('non-exhaustive-mode', () => {
       it('basic functions work', () => {
-        const ext = new TextExtraction('aaaa', [
-          {
-            pattern: /a/,
-            nonExhaustiveModeMaxMatchCount: 1,
-            renderText: () => 'z',
-          },
-        ]);
         expect(
-          ext
+          new TextExtraction('aaaa', [
+            {
+              pattern: /a/,
+              nonExhaustiveModeMaxMatchCount: 1,
+              renderText: () => 'z',
+            },
+          ])
             .parse()
             .map((chunk) => chunk.children)
             .join(''),
         ).toMatchInlineSnapshot(`"zaaa"`);
+
+        expect(
+          new TextExtraction('aaaa', [
+            {
+              pattern: /a/,
+              nonExhaustiveModeMaxMatchCount: 2,
+              renderText: () => 'z',
+            },
+          ])
+            .parse()
+            .map((chunk) => chunk.children)
+            .join(''),
+        ).toMatchInlineSnapshot(`"zzaa"`);
+
+        expect(
+          new TextExtraction('aaaa', [
+            {
+              pattern: /a/,
+              nonExhaustiveModeMaxMatchCount: 10,
+              renderText: () => 'z',
+            },
+          ])
+            .parse()
+            .map((chunk) => chunk.children)
+            .join(''),
+        ).toMatchInlineSnapshot(`"zzzz"`);
       });
+
       test.each([
         ['undefined is', undefined, 'aaaa', 'zzzz'],
         ['null is', null, 'aaaa', 'zzzz'],


### PR DESCRIPTION
Fixes #72

Since the way we parse text in this library basically implies the global flag is always enabled, we've had a request for non-global mode.

The way to enable it is by passing `nonExhaustiveModeMaxMatchCount: 1` as an extra prop for your parse pattern configuration.

If you want, you can change the number higher to accept a certain number of matches, and then stop.
For Example: if you were going to give URL previews, but only to the first 2 URLs in a given chunk of Text, you would pass `nonExhaustiveModeMaxMatchCount: 2`

## TODO
- [x] Verify this is what is desired by #72
- [x] Add Basic Tests

## Out-of-scope
- Rework things to pass a test of nested matchers `[b]Bold[/b][i]italic[b]italic and bold[/b][/i]` (This may be a bug in the fundamental architecture) -- discuss in #81