### PR TITLE
expose ParseShape type

### DIFF
--- a/src/ParsedText.d.ts
+++ b/src/ParsedText.d.ts
@@ -34,7 +34,7 @@ declare module 'react-native-parsed-text' {
     nonExhaustiveModeMaxMatchCount?: number;
   }
 
-  type ParseShape = DefaultParseShape | CustomParseShape;
+  export type ParseShape = DefaultParseShape | CustomParseShape;
 
   export interface ParsedTextProps extends TextProps {
     parse?: ParseShape[];


### PR DESCRIPTION
Hi there 👋🏻

I have encountered this great library while using `react-native-gifted-chat`. I have just opened a PR there regarding the typings. [Had to extract `ParsedShape` type using `ParsedTextProps`.](https://github.com/FaridSafi/react-native-gifted-chat/pull/2259) 

I think directly exporting `ParsedShape` type would be brilliant for the long term 👍